### PR TITLE
Fixing bugs in "Select Channels In Tree" command

### DIFF
--- a/VeriStandCustomControls/PWMControlViewModel.cs
+++ b/VeriStandCustomControls/PWMControlViewModel.cs
@@ -293,12 +293,15 @@ namespace NationalInstruments.VeriStand.CustomControlsExamples
             IEnumerable<string> frequencyChannels = selection.Select(item => item.Model)
                 .OfType<PulseWidthModulationControlModel>()
                 .Select(model => model.FrequencyChannel)
+                .Where(channel => !string.IsNullOrEmpty(channel))
                 .ToList();
             IEnumerable<string> dutyCycleChannels = selection.Select(item => item.Model)
                 .OfType<PulseWidthModulationControlModel>()
                 .Select(model => model.DutyCycleChannel)
+                .Where(channel => !string.IsNullOrEmpty(channel))
                 .ToList();
-            host.GetSharedExportedValue<SystemDefinitionPaletteControl>().SelectNodes(dutyCycleChannels.Concat(frequencyChannels));
+            var systemDefinitionPalette = SystemDefinitionPaletteControl.Activate(site);
+            systemDefinitionPalette.SelectNodes(dutyCycleChannels.Concat(frequencyChannels));
         }
 
         /// <summary>


### PR DESCRIPTION
This set of changes does the following:

- Fixes a crash when executing the "Select Channels in Tree" command
- Fixes an issue with the expected items not becoming selected in the system definition tree upon executing the "Select Channels in Tree" command when one of the control's channels is not currently configured/mapped.