### PR TITLE
Update File Paths for VeriStand 2021

### DIFF
--- a/VeriStand.CustomApplication/VeriStand.CustomApplication.csproj
+++ b/VeriStand.CustomApplication/VeriStand.CustomApplication.csproj
@@ -36,7 +36,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
-    <VeriStandDir>c:\Program Files\National Instruments\VeriStand 2020</VeriStandDir>
+    <VeriStandDir>c:\Program Files\National Instruments\VeriStand 2021</VeriStandDir>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="NationalInstruments.Core">

--- a/VeriStandCustomControls/ARCHITECTURE.md
+++ b/VeriStandCustomControls/ARCHITECTURE.md
@@ -6,7 +6,7 @@ This document provides a high level overview of the components required to plugi
 ### MEF
 VeriStand uses the [MEF Framework](https://docs.microsoft.com/en-us/dotnet/framework/mef/) as the basis of its plugin model. To use a plugin with VeriStand:
 1. Place the plugin in a known directory. The *.csproj* file copies the built output to the plugin directory. If your file path is different, update the [project file](CustomControlsExamples.csproj).
->     <PostBuildEvent>xcopy /y "$(TargetPath)" "C:\Users\Public\Documents\National Instruments\NI VeriStand 2020\Custom UI Manager Controls\"</PostBuildEvent>
+>     <PostBuildEvent>xcopy /y "$(TargetPath)" "C:\Users\Public\Documents\National Instruments\NI VeriStand 2021\Custom UI Manager Controls\"</PostBuildEvent>
 
 2. Use attributes to identify individual plugin classes.
 > [Export(typeof(TYPENAME))] // Or this may be a derived attribute.

--- a/VeriStandCustomControls/CustomControlsExamples.csproj
+++ b/VeriStandCustomControls/CustomControlsExamples.csproj
@@ -30,7 +30,7 @@
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
   <PropertyGroup>
-    <VeriStandDir>c:\Program Files\National Instruments\VeriStand 2020</VeriStandDir>
+    <VeriStandDir>c:\Program Files\National Instruments\VeriStand 2021</VeriStandDir>
     <DefineConstants>MUTATE2020;MUTATE2020R4;MUTATE2021</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
@@ -176,6 +176,6 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>xcopy /y "$(TargetPath)" "C:\Users\Public\Documents\National Instruments\NI VeriStand 2020\Custom UI Manager Controls\"</PostBuildEvent>
+    <PostBuildEvent>xcopy /y "$(TargetPath)" "C:\Users\Public\Documents\National Instruments\NI VeriStand 2021\Custom UI Manager Controls\"</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/VeriStandCustomControls/CustomControlsExamples.csproj.user
+++ b/VeriStandCustomControls/CustomControlsExamples.csproj.user
@@ -2,6 +2,6 @@
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <StartAction>Program</StartAction>
-    <StartProgram>C:\Program Files\National Instruments\VeriStand 2020\VeriStand.exe</StartProgram>
+    <StartProgram>C:\Program Files\National Instruments\VeriStand 2021\VeriStand.exe</StartProgram>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This set of changes updates file paths in the project files to reflect the current major version of VeriStand (2021).