### PR TITLE
Fixing CustomControlsExamples.csproj build error

### DIFF
--- a/VeriStandCustomControls/CustomControlsExamples.csproj
+++ b/VeriStandCustomControls/CustomControlsExamples.csproj
@@ -34,6 +34,7 @@
     <DefineConstants>MUTATE2020;MUTATE2020R4;MUTATE2021</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="NationalInstruments.Common, Version=19.0.40.49152, Culture=neutral, PublicKeyToken=dc6ad606294fc298" />
     <Reference Include="NationalInstruments.Controls">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(VeriStandDir)\NationalInstruments.Controls.dll</HintPath>

--- a/VeriStandCustomControls/TwoChannelAdorner.xaml.cs
+++ b/VeriStandCustomControls/TwoChannelAdorner.xaml.cs
@@ -106,7 +106,7 @@ namespace NationalInstruments.VeriStand.CustomControlsExamples
         /// <summary>
         /// List of keys to ignore when pressed over the adorner
         /// </summary>
-        private static List<Key> _keysToEat = new List<Key>()
+        private static readonly List<Key> _keysToEat = new List<Key>()
         {
             Key.Up, Key.Down, Key.Left, Key.Right, Key.PageDown, Key.PageUp, Key.Home, Key.End
         };


### PR DESCRIPTION
**Justification**

While building the CustomControlsExample project, the build fails with an error suggesting the addition of a reference to the assembly 'NationalInstruments.Common, Version=19.0.40.49152, Culture=neutral, PublicKeyToken=dc6ad606294fc298'. The error points to the TagFactory.cs file, which includes the AnalogWaveform.

Reference: PR 686795: Add a way to store a DoubleAnalogWaveform in the iTagService

**Implementation**

- Added reference to NationalInstruments.Common, Version=19.0.40.49152 in the project file
- Small, unrelated tweak to `TwoChannelAdorner` code
